### PR TITLE
Proper namespace CoreExtensions and only extend when needed.

### DIFF
--- a/lib/rqrcode/core_ext/array.rb
+++ b/lib/rqrcode/core_ext/array.rb
@@ -1,5 +1,5 @@
 require 'rqrcode/core_ext/array/behavior'
 
 class Array #:nodoc:
-  include CoreExtensions::Array::Behavior
+  include RQRCode::CoreExtensions::Array::Behavior
 end

--- a/lib/rqrcode/core_ext/array/behavior.rb
+++ b/lib/rqrcode/core_ext/array/behavior.rb
@@ -1,9 +1,12 @@
-module CoreExtensions #:nodoc:
-  module Array #:nodoc:
-    module Behavior
-      def extract_options!
-        last.is_a?(::Hash) ? pop : {}
+module RQRCode
+  module CoreExtensions #:nodoc:
+    module Array #:nodoc:
+      module Behavior
+        def extract_options!
+          last.is_a?(::Hash) ? pop : {}
+        end unless [].respond_to?(:extract_options!)
       end
     end
   end
 end
+

--- a/lib/rqrcode/core_ext/integer.rb
+++ b/lib/rqrcode/core_ext/integer.rb
@@ -1,5 +1,5 @@
 require 'rqrcode/core_ext/integer/bitwise'
 
 class Integer #:nodoc:
-  include CoreExtensions::Integer::Bitwise
+  include RQRCode::CoreExtensions::Integer::Bitwise
 end

--- a/lib/rqrcode/core_ext/integer/bitwise.rb
+++ b/lib/rqrcode/core_ext/integer/bitwise.rb
@@ -1,9 +1,11 @@
-module CoreExtensions #:nodoc:
-  module Integer #:nodoc:
-    module Bitwise
-      def rszf(count)
-        # zero fill right shift
-        (self >> count) & ((2 ** ((self.size * 8) - count))-1)
+module RQRCode
+  module CoreExtensions #:nodoc:
+    module Integer #:nodoc:
+      module Bitwise
+        def rszf(count)
+          # zero fill right shift
+          (self >> count) & ((2 ** ((self.size * 8) - count))-1)
+        end
       end
     end
   end


### PR DESCRIPTION
So this vs using the top level CoreExtensions namespace.

```
module RQRCode
  module CoreExtensions #:nodoc:

  end
end
```

I also made Array#extract_options! not trump existing Array#extract_options! in latest ActiveSupport since it has some additoinal logic in it's implementation.
