### PR TITLE
Add crispEdges attribute to disable antialiasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,42 @@ require 'rqrcode'
 
 qrcode = RQRCode::QRCode.new("http://github.com/")
 image = qrcode.as_png
-html = qrcode.as_html
 svg = qrcode.as_svg
+html = qrcode.as_html
 string = qrcode.to_s
+```
+
+## Image Rendering
+### SVG
+
+The SVG renderer will produce a stand-alone SVG as a `String`
+
+```ruby
+qrcode = RQRCode::QRCode.new("http://github.com/")
+# With default options specified explicitly
+svg = qrcode.as_svg(offset: 0, color: '000', 
+                    shape_rendering: 'crispEdges', 
+                    module_size: 11)
+```
+
+### PNG
+
+The library can produce a PNG. Result will be a `ChunkyPNG::Image` instance.
+
+```ruby
+qrcode = RQRCode::QRCode.new("http://github.com/")
+# With default options specified explicitly
+png = qrcode.as_png(
+          resize_gte_to: false,
+          resize_exactly_to: false,
+          fill: 'white',
+          color: 'black',
+          size: 120,
+          border_modules: 4,
+          file: false,
+          module_px_size: 6,
+          output_file: nil # path to write
+          )
 ```
 
 ## HTML Rendering

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -22,7 +22,7 @@ module RQRCode
         dimension = (self.module_count*module_size) + (2*offset)
 
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
-        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}">}
+        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" shape-rendering="crispEdges">}
         close_tag = "</svg>"
 
         result = []

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -2,9 +2,9 @@
 # Code from: https://github.com/samvincent/rqrcode-rails3
 module RQRCode
   module Export
-    
+
     module SVG
-      
+
       # Render the SVG from the Qrcode.
       #
       # Options:

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -16,7 +16,7 @@ module RQRCode
       def as_svg(options={})
         offset = options[:offset].to_i || 0
         color = options[:color] || "000"
-        color = options[:shape_rendering] || "crispEdges"
+        shape_rendering = options[:shape_rendering] || "crispEdges"
         module_size = options[:module_size] || 11
 
         # height and width dependent on offset and QR complexity

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -16,13 +16,14 @@ module RQRCode
       def as_svg(options={})
         offset = options[:offset].to_i || 0
         color = options[:color] || "000"
+        color = options[:shape_rendering] || "crispEdges"
         module_size = options[:module_size] || 11
 
         # height and width dependent on offset and QR complexity
         dimension = (self.module_count*module_size) + (2*offset)
 
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
-        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" shape-rendering="crispEdges">}
+        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
 
         result = []


### PR DESCRIPTION
Antialiasing on SVG can affect QR success rate. Also, this ensures the pixels grid-snap, which helps with small gaps between the squares.