### PR TITLE
Fix output_file arg for .as_png in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ png = qrcode.as_png(
           color: 'black',
           size: 120,
           border_modules: 4,
-          file: false,
           module_px_size: 6,
-          output_file: nil # path to write
+          file: nil # path to write
           )
 ```
 


### PR DESCRIPTION
The output file arg must be specified as `:file`. `:output_file` is no longer used apparently.