### PR TITLE
Add support for numeric QR codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /pkg/
 .rvmrc
 Gemfile.lock
+*.sublime-project
+*.sublime-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.2.3
   - 2.1.6
   - 2.0.0
   - 1.9.3
-  - 1.8.7
-  - jruby-18mode
   - jruby-19mode

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*0.8.0* (Dec 8, 2015)
+
+- Added numeric QR code support
+
 *0.7.0* (Aug 15, 2015)
 
 - Added shape_rendering option for as_svg

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 *0.8.0* (Dec 8, 2015)
 
 - Added numeric QR code support
+- Dropped Ruby v1.8 support
 
 *0.7.0* (Aug 15, 2015)
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ end
 
 Sometimes you may want to specify the QR code mode explicitly. 
 
-It is done voia the `mode` option. Allowed values are: `number`, `alphanumeric`, `8bit_byte` and `kanji`.
+It is done via the `mode` option. Allowed values are: `number`, `alphanumeric`, `8bit_byte` and `kanji`.
 
 ```ruby
 qr = RQRCode::QRCode.new( '1234567890', :size => 2, :level => :m, :mode => :number )

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ end
 
 Sometimes you may want to specify the QR code mode explicitly. 
 
-It is done via the `mode` option. Allowed values are: `number`, `alphanumeric`, `8bit_byte` and `kanji`.
+It is done via the `mode` option. Allowed values are: `number`, `alphanumeric` and `byte_8bit`.
 
 ```ruby
 qr = RQRCode::QRCode.new( '1234567890', :size => 2, :level => :m, :mode => :number )

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## Short changelog
 
+*0.8.0* (Dec 8, 2015)
+
+- Added numeric QR code support
+
 *0.7.0* (Aug 15, 2015)
 
 - Added shape_rendering option for as_svg
@@ -139,6 +143,17 @@ qr.modules.each do |row|
     print "\n"
 end
 ```
+
+## Specifying QR code mode
+
+Sometimes you may want to specify the QR code mode explicitly. 
+
+It is done voia the `mode` option. Allowed values are: `number`, `alphanumeric`, `8bit_byte` and `kanji`.
+
+```ruby
+qr = RQRCode::QRCode.new( '1234567890', :size => 2, :level => :m, :mode => :number )
+```
+
 
 ## API Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 *0.8.0* (Dec 8, 2015)
 
 - Added numeric QR code support
+- Dropped Ruby v1.8 support
 
 *0.7.0* (Aug 15, 2015)
 

--- a/lib/rqrcode/qrcode/qr_bit_buffer.rb
+++ b/lib/rqrcode/qrcode/qr_bit_buffer.rb
@@ -68,6 +68,13 @@ module RQRCode
       put(length, QRUtil.get_length_in_bits(QRMODE[:mode_alpha_numk], @version))
       
     end
+
+    def numeric_encoding_start(length)
+      
+      put( QRMODE[:mode_number], 4 )
+      put(length, QRUtil.get_length_in_bits(QRMODE[:mode_number], @version))
+      
+    end
     
     def pad_until(prefered_size)
       # Align on byte

--- a/lib/rqrcode/qrcode/qr_code.rb
+++ b/lib/rqrcode/qrcode/qr_code.rb
@@ -18,6 +18,13 @@ module RQRCode #:nodoc:
     :mode_kanji         => 1 << 3
   }
 
+  QRMODE_NAME = {
+    :number        => :mode_number,
+    :alphanumeric  => :mode_alpha_numk,
+    :'8bit_byte'   => :mode_8bit_byte,
+    :kanji         => :mode_kanji
+  }
+
   QRERRORCORRECTLEVEL = {
     :l => 1,
     :m => 0,
@@ -84,7 +91,7 @@ module RQRCode #:nodoc:
   # and an optional hash of any other. Here's a few examples:
   #
   #  qr = RQRCode::QRCode.new('hello world')
-  #  qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m )
+  #  qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m, :mode => :number )
   #
 
   class QRCode
@@ -117,7 +124,8 @@ module RQRCode #:nodoc:
 
       @data                 = string
 
-      mode                  = QRAlphanumeric.valid_data?( @data ) ? :mode_alpha_numk : :mode_8bit_byte
+      mode                  = QRMODE_NAME[(options[:mode] || '').to_sym]
+      mode                  ||= QRAlphanumeric.valid_data?( @data ) ? :mode_alpha_numk : :mode_8bit_byte  # deprecate?
 
       max_size_array        = QRMAXDIGITS[level][mode]
       size                  = options[:size] || smallest_size_for(string, max_size_array)
@@ -130,7 +138,15 @@ module RQRCode #:nodoc:
       @version              = size
       @module_count         = @version * 4 + QRPOSITIONPATTERNLENGTH
       @modules              = Array.new( @module_count )
-      @data_list            = (mode == :mode_alpha_numk) ? QRAlphanumeric.new( @data ) : QR8bitByte.new( @data )
+      @data_list            =
+        case mode
+        when :mode_number
+          QRNumeric.new( @data )
+        when :mode_alpha_numk
+          QRAlphanumeric.new( @data )
+        else
+          QR8bitByte.new( @data )
+
       @data_cache           = nil
       self.make
     end

--- a/lib/rqrcode/qrcode/qr_code.rb
+++ b/lib/rqrcode/qrcode/qr_code.rb
@@ -91,7 +91,7 @@ module RQRCode #:nodoc:
   # and an optional hash of any other. Here's a few examples:
   #
   #  qr = RQRCode::QRCode.new('hello world')
-  #  qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m, :mode => :number )
+  #  qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m, :mode => :alphanumeric )
   #
 
   class QRCode
@@ -106,8 +106,13 @@ module RQRCode #:nodoc:
     #      * Level :m 15% of code can be restored
     #      * Level :q 25% of code can be restored
     #      * Level :h 30% of code can be restored (default :h)
+    #   # mode   - the mode of the qrcode (defaults to alphanumeric or 8bit_byte, depending on the input data):
+    #      * :number
+    #      * :alphanumeric
+    #      * :'8bit_byte'
+    #      * :kanji
     #
-    #   qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m )
+    #   qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m, :mode => :alphanumeric )
     #
 
     def initialize( string, *args )

--- a/lib/rqrcode/qrcode/qr_code.rb
+++ b/lib/rqrcode/qrcode/qr_code.rb
@@ -21,7 +21,7 @@ module RQRCode #:nodoc:
   QRMODE_NAME = {
     :number        => :mode_number,
     :alphanumeric  => :mode_alpha_numk,
-    :'8bit_byte'   => :mode_8bit_byte,
+    :byte_8bit     => :mode_8bit_byte,
     :kanji         => :mode_kanji
   }
 
@@ -106,10 +106,10 @@ module RQRCode #:nodoc:
     #      * Level :m 15% of code can be restored
     #      * Level :q 25% of code can be restored
     #      * Level :h 30% of code can be restored (default :h)
-    #   # mode   - the mode of the qrcode (defaults to alphanumeric or 8bit_byte, depending on the input data):
+    #   # mode   - the mode of the qrcode (defaults to alphanumeric or byte_8bit, depending on the input data):
     #      * :number
     #      * :alphanumeric
-    #      * :'8bit_byte'
+    #      * :byte_8bit
     #      * :kanji
     #
     #   qr = RQRCode::QRCode.new('hello world', :size => 1, :level => :m, :mode => :alphanumeric )

--- a/lib/rqrcode/qrcode/qr_code.rb
+++ b/lib/rqrcode/qrcode/qr_code.rb
@@ -21,8 +21,7 @@ module RQRCode #:nodoc:
   QRMODE_NAME = {
     :number        => :mode_number,
     :alphanumeric  => :mode_alpha_numk,
-    :byte_8bit     => :mode_8bit_byte,
-    :kanji         => :mode_kanji
+    :byte_8bit     => :mode_8bit_byte
   }
 
   QRERRORCORRECTLEVEL = {

--- a/lib/rqrcode/qrcode/qr_code.rb
+++ b/lib/rqrcode/qrcode/qr_code.rb
@@ -146,6 +146,7 @@ module RQRCode #:nodoc:
           QRAlphanumeric.new( @data )
         else
           QR8bitByte.new( @data )
+        end
 
       @data_cache           = nil
       self.make

--- a/lib/rqrcode/qrcode/qr_numeric.rb
+++ b/lib/rqrcode/qrcode/qr_numeric.rb
@@ -1,0 +1,47 @@
+module RQRCode
+
+  NUMERIC = ['0','1','2','3','4','5','6','7','8','9'].freeze
+
+  class QRNumeric
+    attr_reader :mode
+
+    def initialize( data )
+      @mode = QRMODE[:mode_number]
+
+      raise QRCodeArgumentError, "Not a numeric string `#{data}`" unless QRNumeric.valid_data?(data)
+
+      @data = data;
+    end
+
+
+    def get_length
+      @data.size
+    end
+
+    def self.valid_data? data
+      data.each_char do |s|
+        return false if NUMERIC.index(s).nil?
+      end
+      true
+    end
+
+
+    def write( buffer)
+      buffer.numeric_encoding_start(get_length)
+
+      (@data.size).times do |i|
+        if i % 2 == 0
+          if i == (@data.size - 1)
+            value = NUMERIC.index(@data[i])
+            buffer.put( value, 6 )
+          else
+            value = (NUMERIC.index(@data[i]) * 45) + NUMERIC.index(@data[i+1])
+            buffer.put( value, 11 )
+          end
+        end
+      end
+
+
+    end
+  end
+end

--- a/lib/rqrcode/qrcode/qr_numeric.rb
+++ b/lib/rqrcode/qrcode/qr_numeric.rb
@@ -30,18 +30,37 @@ module RQRCode
       buffer.numeric_encoding_start(get_length)
 
       (@data.size).times do |i|
-        if i % 2 == 0
-          if i == (@data.size - 1)
-            value = NUMERIC.index(@data[i])
-            buffer.put( value, 6 )
-          else
-            value = (NUMERIC.index(@data[i]) * 45) + NUMERIC.index(@data[i+1])
-            buffer.put( value, 11 )
+        if i % 3 == 0
+          chars = @data[i]
+
+          if @data[i + 1].present?
+            chars << @data[i + 1]
           end
+
+          if @data[i + 2].present?
+            chars << @data[i + 2]
+          end
+
+          bit_length = get_bit_length(chars.length)
+          buffer.put( get_code(chars), bit_length )
         end
       end
+    end
 
+    private
 
+    NUMBER_LENGTH = {
+      3 => 10,
+      2 => 7,
+      1 => 4
+    }.freeze
+
+    def get_bit_length(length)
+      NUMBER_LENGTH[length]
+    end
+
+    def get_code(chars)
+      chars.to_i
     end
   end
 end

--- a/lib/rqrcode/version.rb
+++ b/lib/rqrcode/version.rb
@@ -1,3 +1,3 @@
 module RQRCode
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/test/test_rqrcode.rb
+++ b/test/test_rqrcode.rb
@@ -96,6 +96,13 @@ class QRCodeTest < Test::Unit::TestCase
     assert_equal "xxxxxxx xxx   xxxxxxx\n", qr.to_s[0..21]
   end
 
+  def test_numeric_2_M
+    data = '279042272585972554922067893753871413584876543211601021503002'
+    
+    qr = RQRCode::QRCode.new(data, size: 2, level: :m, mode: :number)
+    assert_equal "xxxxxxx   x x x   xxxxxxx\n", qr.to_s[0..25]
+  end
+
   def test_rszf_error_not_thrown
     assert RQRCode::QRCode.new('2 1058 657682')
     assert RQRCode::QRCode.new("40952", :size => 1, :level => :h)


### PR DESCRIPTION
Numeric QR codes can now be enabled with an extra initialization parameter:

```ruby
qr = RQRCode::QRCode.new( '1234567890', :size => 2, :level => :m, :mode => :number )
```
