### PR TITLE
don't require present?(); simplify string chunking code

### DIFF
--- a/lib/rqrcode/qrcode/qr_numeric.rb
+++ b/lib/rqrcode/qrcode/qr_numeric.rb
@@ -31,16 +31,7 @@ module RQRCode
 
       (@data.size).times do |i|
         if i % 3 == 0
-          chars = @data[i]
-
-          if @data[i + 1].present?
-            chars << @data[i + 1]
-          end
-
-          if @data[i + 2].present?
-            chars << @data[i + 2]
-          end
-
+          chars = @data[i, 3]
           bit_length = get_bit_length(chars.length)
           buffer.put( get_code(chars), bit_length )
         end


### PR DESCRIPTION
present?() is a Rails-ism from Active Support, which is not a declared
dependency of rQRCode and thus brakes QRNumeric. In any case, it can
be sidestepped by calling the [start, length] form of String#[].