### PR TITLE
Svg optimization

### DIFF
--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -26,11 +26,6 @@ module RQRCode
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
         open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 #{dimension} #{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
-        style_tag = <<-EOS
-<style type="text/css"><![CDATA[
-rect {width:#{module_size}px; height:#{module_size}px}
-]]></style>
-EOS
         fixpoints = <<-EOS
 <defs>
 <g id="fixpoint" fill="##{color}">
@@ -50,7 +45,7 @@ EOS
             x = r*module_size + offset
 
             next unless self.is_dark(c, r)
-            tmp << %{<rect x="#{x}" y="#{y}"/>} unless fixpoint?(r, c)
+            tmp << %{<rect width="#{module_size}" height="#{module_size}" x="#{x}" y="#{y}"/>} unless fixpoint?(r, c)
           end
           result << tmp.join
         end
@@ -60,7 +55,7 @@ EOS
           result.unshift %{<rect width="#{dimension}" height="#{dimension}" x="0" y="0" style="fill:##{options[:fill]}"/>}
         end
 
-        [xml_tag, open_tag, style_tag, fixpoints, result, close_tag].flatten.join("\n")
+        [xml_tag, open_tag, fixpoints, result, close_tag].flatten.join("\n")
       end
 
       def fixpoint?(r, c)

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -30,8 +30,18 @@ module RQRCode
 <style type="text/css"><![CDATA[
 rect {width:#{module_size}px; height:#{module_size}px}
 ]]></style>
-        EOS
-
+EOS
+        fixpoints = <<-EOS
+<defs>
+<g id="fixpoint" fill="##{color}">
+<path d="M 0 0 h #{module_size * 7} v #{module_size * 7} h -#{module_size * 7} v -#{module_size} h #{module_size * 6} v -#{module_size * 5} h -#{module_size* 5} v #{module_size * 5} h -#{module_size} z"/>
+<path d="M #{module_size * 2} #{module_size * 2} h #{module_size * 3} v #{module_size * 3} h -#{module_size * 3} z"/>
+</g>
+</defs>
+<use xlink:href="#fixpoint" x="#{offset}" y="#{offset}"/>
+<use xlink:href="#fixpoint" x="#{(self.module_count - 7) * module_size + offset}" y="#{offset}"/>
+<use xlink:href="#fixpoint" x="#{offset}" y="#{(self.module_count - 7) * module_size + offset}"/>
+EOS
         result = [%{<g fill="##{options[:color]}">}]
         self.modules.each_index do |c|
           tmp = []
@@ -40,7 +50,7 @@ rect {width:#{module_size}px; height:#{module_size}px}
             x = r*module_size + offset
 
             next unless self.is_dark(c, r)
-            tmp << %{<rect x="#{x}" y="#{y}"/>}
+            tmp << %{<rect x="#{x}" y="#{y}"/>} unless fixpoint?(r, c)
           end
           result << tmp.join
         end
@@ -50,7 +60,12 @@ rect {width:#{module_size}px; height:#{module_size}px}
           result.unshift %{<rect width="#{dimension}" height="#{dimension}" x="0" y="0" style="fill:##{options[:fill]}"/>}
         end
 
-        [xml_tag, open_tag, style_tag, result, close_tag].flatten.join("\n")
+        [xml_tag, open_tag, style_tag, fixpoints, result, close_tag].flatten.join("\n")
+      end
+
+      def fixpoint?(r, c)
+        (0..6).member?(c) && ((0..6).member?(r) || (self.module_count-7..self.module_count-1).member?(r)) ||
+        (self.module_count-7..self.module_count-1).member?(c) && (0..6).member?(r)
       end
     end
   end

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -24,7 +24,7 @@ module RQRCode
         dimension = (self.module_count*module_size) + (2*offset)
 
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
-        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" shape-rendering="#{shape_rendering}">}
+        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="#{dimension}" height="#{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
 
         result = []

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -26,8 +26,13 @@ module RQRCode
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
         open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 #{dimension} #{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
+        style_tag = <<-EOS
+<style type="text/css"><![CDATA[
+rect {width:#{module_size}px; height:#{module_size}px}
+]]></style>
+        EOS
 
-        result = []
+        result = [%{<g fill="##{options[:color]}">}]
         self.modules.each_index do |c|
           tmp = []
           self.modules.each_index do |r|
@@ -35,16 +40,17 @@ module RQRCode
             x = r*module_size + offset
 
             next unless self.is_dark(c, r)
-            tmp << %{<rect width="#{module_size}" height="#{module_size}" x="#{x}" y="#{y}" style="fill:##{color}"/>}
+            tmp << %{<rect x="#{x}" y="#{y}"/>}
           end
           result << tmp.join
         end
+        result << '</g>'
 
         if options[:fill]
           result.unshift %{<rect width="#{dimension}" height="#{dimension}" x="0" y="0" style="fill:##{options[:fill]}"/>}
         end
 
-        [xml_tag, open_tag, result, close_tag].flatten.join("\n")
+        [xml_tag, open_tag, style_tag, result, close_tag].flatten.join("\n")
       end
     end
   end

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -42,7 +42,7 @@ EOS
 <use xlink:href="#fixpoint" x="#{(self.module_count - 7) * module_size + offset}" y="#{offset}"/>
 <use xlink:href="#fixpoint" x="#{offset}" y="#{(self.module_count - 7) * module_size + offset}"/>
 EOS
-        result = [%{<g fill="##{options[:color]}">}]
+        result = [%{<g fill="##{color}">}]
         self.modules.each_index do |c|
           tmp = []
           self.modules.each_index do |r|

--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -24,7 +24,7 @@ module RQRCode
         dimension = (self.module_count*module_size) + (2*offset)
 
         xml_tag = %{<?xml version="1.0" standalone="yes"?>}
-        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="#{dimension}" height="#{dimension}" shape-rendering="#{shape_rendering}">}
+        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 #{dimension} #{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
 
         result = []


### PR DESCRIPTION
The exported SVG file size is reduced by moving width, height and fill attributes away from the rect elements. A further reduction in file size is made by using reusable fixpoints.

The published gem creates a file of 25,792 bytes, but with this proposed code is is only 7,450 bytes, with no compression used. The text I used for this benchmark is: "http://github.com/"

The image is now dynamically resizable in web pages.
