### PR TITLE
Add class to export/html.rb

### DIFF
--- a/lib/rqrcode/export/html.rb
+++ b/lib/rqrcode/export/html.rb
@@ -25,7 +25,7 @@ module RQRCode
 
       class Row < Struct.new(:qr, :qr_module, :row_index)
         def as_html
-          ["<tr class=\"qr\">", cells.map(&:as_html).join, '</tr>'].join
+          ['<tr>', cells.map(&:as_html).join, '</tr>'].join
         end
 
         def cells

--- a/lib/rqrcode/export/html.rb
+++ b/lib/rqrcode/export/html.rb
@@ -4,7 +4,7 @@ module RQRCode
     module HTML
 
       def as_html
-        ['<table>', rows.as_html, '</table>'].join
+        ["<table class=\"qr\">", rows.as_html, '</table>'].join
       end
 
       private
@@ -25,7 +25,7 @@ module RQRCode
 
       class Row < Struct.new(:qr, :qr_module, :row_index)
         def as_html
-          ['<tr>', cells.map(&:as_html).join, '</tr>'].join
+          ["<tr class=\"qr\">", cells.map(&:as_html).join, '</tr>'].join
         end
 
         def cells


### PR DESCRIPTION
Added a class to the table to be used in css and avoid conflicts with other table.

Css code can now be re arranged as: (Sass)

`.qr {`
  `border-width: 0;`
  `border-style: none;`
  `border-color: #0000ff;`
  `border-collapse: collapse;`
  `td {`
  `border-left: solid 10px #000;`
  `padding: 0; `
  `margin: 0; `
  `width: 0px; `
  `height: 10px; `
  `}`
`}`


`td.black { border-color: #000; }`
`td.white { border-color: #fff; }`