### PR TITLE
Add license to gemspec

### DIFF
--- a/lib/rqrcode/version.rb
+++ b/lib/rqrcode/version.rb
@@ -1,3 +1,3 @@
 module RQRCode
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -18,7 +18,7 @@ ready to be displayed in the way you choose.
 EOF
 
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6')
-  
+
   s.add_dependency 'chunky_png', "~> 1.0"
 
   s.add_development_dependency "rake"

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Björn Blomqvist","Duncan Robertson"]
   s.email       = ["darwin@bits2life.com"]
+  s.license     = "MIT"
   s.homepage    = "https://github.com/whomwah/rqrcode"
   s.summary     = "A library to encode QR Codes"
   s.description = <<EOF


### PR DESCRIPTION
I noticed this was missing when auditing gems this morning. I also took the liberty of bumping the patch level so that this change will propagate to RubyGems. 