### PR TITLE
Add HTML5 inline SVG support.

### DIFF
--- a/lib/rqrcode/export/svg.rb
+++ b/lib/rqrcode/export/svg.rb
@@ -23,8 +23,8 @@ module RQRCode
         # height and width dependent on offset and QR complexity
         dimension = (self.module_count*module_size) + (2*offset)
 
-        xml_tag = %{<?xml version="1.0" standalone="yes"?>}
-        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" shape-rendering="#{shape_rendering}">}
+        xml_tag = options.has_key?(:xml_declaration) && !options[:xml_declaration] ? nil : %{<?xml version="1.0" standalone="yes"?>}
+        open_tag = %{<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events" width="#{dimension}" height="#{dimension}" viewBox="0 0 #{dimension} #{dimension}" shape-rendering="#{shape_rendering}">}
         close_tag = "</svg>"
 
         result = []
@@ -44,7 +44,7 @@ module RQRCode
           result.unshift %{<rect width="#{dimension}" height="#{dimension}" x="0" y="0" style="fill:##{options[:fill]}"/>}
         end
 
-        [xml_tag, open_tag, result, close_tag].flatten.join("\n")
+        [xml_tag, open_tag, result, close_tag].compact.flatten.join("\n")
       end
     end
   end


### PR DESCRIPTION
Hello,
At first, thank you for your great gem! rQRCode is very handy and easy to use.

I'd like to embed SVG outout to HTML, like follwing;
~~~erb
<div>
 <p>Scan this code: </p>
 <%= raw RQRCode::QRCode.new(draft_url(@draft)).as_svg(xml_decleration: false) %>
</div>
~~~

To allow embedding as such style,  I need to;
1) remove XML declaration tag 
2) add `viewBox` attribute to `<svg>` element

This PR adds `:xml_declaration` option for 1.

Thanks,