### PR TITLE
Fix qrcode doesn't pass options to core lib

### DIFF
--- a/lib/rqrcode/qrcode/qrcode.rb
+++ b/lib/rqrcode/qrcode/qrcode.rb
@@ -11,7 +11,7 @@ module RQRCode #:nodoc:
     attr_reader :qrcode
 
     def initialize(string, *args)
-      @qrcode = RQRCodeCore::QRCode.new(string, args)
+      @qrcode = RQRCodeCore::QRCode.new(string, *args)
     end
   end
 end

--- a/test/rqrcode/qrqcode_test.rb
+++ b/test/rqrcode/qrqcode_test.rb
@@ -3,7 +3,7 @@ require 'rqrcode/data'
 
 describe 'RQRCode' do
   it 'must provide a custom to_s' do
-    qr = RQRCode::QRCode.new('http://kyan.com', size: 1)
+    qr = RQRCode::QRCode.new('http://kyan.com', size: 3)
     qr.to_s[0..50].must_equal("xxxxxxx   x x  xxx    xxxxxxx\nx     x  xxxxx  x x  ")
     qr.to_s(true: 'q', false: 'n')[0..36].must_equal("qqqqqqqnnnqnqnnqqqnnnnqqqqqqq\nqnnnnnq")
     qr.to_s(true: '@')[0..21].must_equal("@@@@@@@   @ @  @@@    ")
@@ -42,5 +42,17 @@ describe 'RQRCode' do
     end
 
     str.must_equal(AS_BASIC)
+  end
+
+  it 'should pass options to rqrcode_core' do
+    options = {
+      size: 5,
+      mode: :alphanumeric
+    }
+
+    qr = RQRCode::QRCode.new('QRCODE', options)
+
+    qr.qrcode.mode.must_equal :mode_alpha_numk
+    qr.qrcode.version.must_equal options[:size]
   end
 end


### PR DESCRIPTION
`rqrcode` ignores any options passed to the constructor. 
It's because the library didn't extract arguments before passing it to `rqrcode_core`'s constructor.
