### PR TITLE
Removing duplicate bundle install

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,4 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - run: |
-       gem install bundler
-       bundle install --jobs 4 --retry 3
        bundle exec rspec


### PR DESCRIPTION
I noticed in the GitHub Action it was running `bundle install` twice (`bundler-cache` runs the bundle also), so I removed the second one.