### PR TITLE
Release 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@
 .rvmrc
 *.sublime-project
 *.sublime-workspace
-Gemfile.lock
 *.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2021-04-23
+## [2.0.0] - 2021-05-06
+
+### Added
+
+- A new `use_path:` option on `.to_svg`. This uses a `<path>` node to greatly reduce the final SVG size. [#108]
+- A new `viewbox:` option on `.to_svg`. Replaces the `svg.width` and `svg.height` attribute with `svg.viewBox` to allow CSS scaling. [#112]
+- A new `svg_attributes:` option on `.to_svg`. Allows you to pass in custom SVG attributes to be used in the `<svg>` tag. [#113]
 
 ### Changed
 
@@ -18,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 
-- The dependency `rqrcode_core` has a tiny breaking change to the `to_s` public method. https://github.com/whomwah/rqrcode_core/blob/master/CHANGELOG.md#breaking-changes
+- The dependency `rqrcode_core-1.0.0` has a tiny breaking change to the `to_s` public method. https://github.com/whomwah/rqrcode_core/blob/master/CHANGELOG.md#breaking-changes
 
 ## [1.2.0] - 2020-12-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-04-23
+
 ### Changed
 
 - README updated
@@ -26,5 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump dependencies
 - fix `required_ruby_version` for Ruby 3 support
 
-[unreleased]: https://github.com/whomwah/rqrcode/compare/v1.2.0...HEAD
+[unreleased]: https://github.com/whomwah/rqrcode/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/whomwah/rqrcode/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/whomwah/rqrcode/compare/v1.1.1...v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- README updated
+- Rakefile cleaned up. You can now just run `rake` which will run specs and fix linting using `standardrb`
+- Small documentation clarification [@smnscp](https://github.com/smnscp)
+- Bump `rqrcode_core` to `~> 1.0`
+
+### Breaking Change
+
+- The dependency `rqrcode_core` has a tiny breaking change to the `to_s` public method. https://github.com/whomwah/rqrcode_core/blob/master/CHANGELOG.md#breaking-changes
+
+## [1.2.0] - 2020-12-26
+
+### Changed
+
+- README updated
+- bump dependencies
+- fix `required_ruby_version` for Ruby 3 support
+
+[unreleased]: https://github.com/whomwah/rqrcode/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/whomwah/rqrcode/compare/v1.1.1...v1.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,68 @@
+PATH
+  remote: .
+  specs:
+    rqrcode (2.0.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    chunky_png (1.4.0)
+    diff-lcs (1.4.4)
+    parallel (1.20.1)
+    parser (3.0.1.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rqrcode_core (1.0.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.12.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.10.1)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
+    standard (1.0.5)
+      rubocop (= 1.12.1)
+      rubocop-performance (= 1.10.1)
+    standardrb (1.0.0)
+      standard
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  rake (~> 13.0)
+  rqrcode!
+  rspec (~> 3.5)
+  standardrb (~> 1.0)
+
+BUNDLED WITH
+   2.2.15

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@
 
 * QR code is trademarked by Denso Wave inc
 * Minimum Ruby version is `>= 2.3`
-* For `rqrcode` releases `< 1.0.0` please use [this README](https://github.com/whomwah/rqrcode/blob/cd2732a68434e6197c219e6c8cbdadfce0c4c4f3/README.md)
+* For `rqrcode` releases `< 2.0.0` please use [this README](https://github.com/whomwah/rqrcode/blob/v1.2.0/README.md)
+* For `rqrcode` releases `< 1.0.0` please use [this README](https://github.com/whomwah/rqrcode/blob/v0.9.0/README.md)
 
 ## Installing
 
 Add this line to your application's `Gemfile`:
 
 ```ruby
-gem 'rqrcode'
+gem "rqrcode", "~> 2.0"
 ```
 
 or install manually:
@@ -26,9 +27,9 @@ gem install rqrcode
 ## Basic usage example
 
 ```ruby
-require 'rqrcode'
+require "rqrcode"
 
-qr = RQRCode::QRCode.new('https://kyan.com')
+qr = RQRCode::QRCode.new("https://kyan.com")
 
 puts qr.to_s
 
@@ -73,7 +74,7 @@ qrcode = RQRCodeCore::QRCode.new('hello world', size: 1, level: :m, mode: :alpha
 
 You probably want to output your QR code in a specific format. We make this easy by providing a bunch of formats to choose from below, each with their own set of options:
 
-### as SVG
+### `as_svg`
 
 The SVG renderer will produce a stand-alone SVG as a `String`
 
@@ -103,14 +104,14 @@ svg_attributes  - A optional hash of custom <svg> attributes. Existing attribute
 ```
 Example
 ```ruby
-require 'rqrcode'
+require "rqrcode"
 
 qrcode = RQRCode::QRCode.new("http://github.com/")
 
 # NOTE: showing with default options specified explicitly
 svg = qrcode.as_svg(
-  color: '000',
-  shape_rendering: 'crispEdges',
+  color: "000",
+  shape_rendering: "crispEdges",
   module_size: 11,
   standalone: true,
   use_path: true,
@@ -122,7 +123,7 @@ svg = qrcode.as_svg(
 
 ![QR code with github url](./images/github-qrcode.svg)
 
-### as PNG
+### `as_png`
 
 The will produce a PNG using the [ChunkyPNG gem](https://github.com/wvanbergen/chunky_png). The result will be a `ChunkyPNG::Image` instance.
 
@@ -172,7 +173,7 @@ Defaults to 120x120 pixels, customizable by option.
 Example
 
 ```ruby
-require 'rqrcode'
+require "rqrcode"
 
 qrcode = RQRCode::QRCode.new("http://github.com/")
 
@@ -181,9 +182,9 @@ png = qrcode.as_png(
   bit_depth: 1,
   border_modules: 4,
   color_mode: ChunkyPNG::COLOR_GRAYSCALE,
-  color: 'black',
+  color: "black",
   file: nil,
-  fill: 'white',
+  fill: "white",
   module_px_size: 6,
   resize_exactly_to: false,
   resize_gte_to: false,
@@ -196,7 +197,7 @@ IO.binwrite("/tmp/github-qrcode.png", png.to_s)
 ![QR code with github url](./images/github-qrcode.png)
 
 
-### as ANSI
+### `as_ansi`
 
 The ANSI renderer will produce as a string with ANSI color codes.
 
@@ -214,14 +215,14 @@ quiet_zone_size - Padding around the edge
 ```
 Example
 ```ruby
-require 'rqrcode'
+require "rqrcode"
 
 qrcode = RQRCode::QRCode.new("http://github.com/")
 
 # NOTE: showing with default options specified explicitly
 svg = qrcode.as_ansi(
   light: "\033[47m", dark: "\033[40m",
-  fill_character: '  ',
+  fill_character: "  ",
   quiet_zone_size: 4
 )
 ```
@@ -260,17 +261,17 @@ $ rake standard:fix # fixes
 
 ## Contributing
 
-The current plan moving forward is to move `as_png`, `as_css`, `as_svg`, `as_ansi` etc into their own gems so they can be managed independently -- ideally -- by people who are interested in maintaining a specific render type. This will leave me to look after `rqrcode_core` gem which I do have time for.
+I am not currently accepting any new renderers as the current `as_png`, `as_svg` and `as_ansi` work for most cases. If you need something different from what's available, the [`rqrcode_core`](https://github.com/whomwah/rqrcode_core) gem gives you access to all the QR Code information you will need so makes it simple to generate your own.
 
-So for example if you only required a `png` rendering of a QR Code, you could simply use the gem `rqrcode_png`. This would eventually mean that the `rqrcode` gem will just become a bucket that pulls in all the existing renderings only and would have deprecated usage over time.
+The motivation for the above is because the rendering side of this gem takes up the most time. It seems that many people want a slightly different version of a QR Code so supporting all the variations would be hard. The easiest way is to empower people to create their own versions which they can manage and share. This is what `rqrcode_core` does.
 
-So, the motivation behind all this change is because the rendering side of this gem takes up the most time. It seems that many people want a slightly different version of a QR Code so supporting all the variations would be hard. The easiest way is to empower people to create their own versions which they can manage and share.
-
-The work won't impact any current users of this gem. What this does mean though is that any contribution PR's should *only* be bug fixes rather than new functionality. Thanks D.
+Any contribution PR's will be greatly accepted. It's important that they are well tested and backwards compatible.
 
 * Fork the project
 * Send a pull request
 * Don't touch the .gemspec, I'll do that when I release a new version
+
+Thanks D.
 
 ## Authors
 

--- a/lib/rqrcode/version.rb
+++ b/lib/rqrcode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RQRCode
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
   spec.add_dependency "rqrcode_core", "~> 1.0"
   spec.add_dependency "chunky_png", "~> 1.0"
-  spec.add_development_dependency "bundler", ">= 2.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "standardrb", "~> 1.0"

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.3"
-  spec.add_dependency "rqrcode_core", "~> 0.2"
+  spec.add_dependency "rqrcode_core", "~> 1.0"
   spec.add_dependency "chunky_png", "~> 1.0"
   spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
### ADDED

- A new `use_path:` option on `.to_svg`. This uses a `<path>` node to greatly reduce the final SVG size. [#108]
- A new `viewbox:` option on `.to_svg`. Replaces the `svg.width` and `svg.height` attribute with `svg.viewBox` to allow CSS scaling. [#112]
- A new `svg_attributes:` option on `.to_svg`. Allows you to pass in custom SVG attributes to be used in the `<svg>` tag. [#113]

### CHANGED

- README updated
- Rakefile cleaned up. You can now just run `rake` which will run specs and fix linting using `standardrb`
- Small documentation clarification [@smnscp](https://github.com/smnscp)
- Bump `rqrcode_core` to `~> 1.0`