### PR TITLE
Add metadata for RubyGems to gemspec

### DIFF
--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -21,7 +21,10 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
     "changelog_uri"   => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
   }
-
+spec.metadata = {
+  "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
+  "changelog_uri" => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
+}
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -19,12 +19,9 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
-    "changelog_uri"   => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
+    "changelog_uri" => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
   }
-spec.metadata = {
-  "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
-  "changelog_uri" => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
-}
+
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |spec|
   EOF
   spec.homepage = "https://github.com/whomwah/rqrcode"
   spec.license = "MIT"
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
+    "changelog_uri"   => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
+  }
 
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
Add a direct link to the Changelog from RubyGems to help with upgrading

Reference: https://guides.rubygems.org/specification-reference/#metadata