### PR TITLE
Bump release 2.1.0 and sync to rqrcode_core 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Sync Gemfile.lock with `rqrcode_core.1.1.0`
+## [2.1.0] - 2021-08-26
+
+- Sync Gemfile.lock with `rqrcode_core.1.2.0` [Adds Multimode Support](https://github.com/whomwah/rqrcode_core#multiple-encoding-support)
 - Add badge for Standard linting
 
 ### Changed
@@ -41,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump dependencies
 - fix `required_ruby_version` for Ruby 3 support
 
-[unreleased]: https://github.com/whomwah/rqrcode/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/whomwah/rqrcode/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/whomwah/rqrcode/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/whomwah/rqrcode/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/whomwah/rqrcode/compare/v1.1.1...v1.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rqrcode (2.0.0)
+    rqrcode (2.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
 
@@ -18,7 +18,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rqrcode_core (1.1.0)
+    rqrcode_core (1.2.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -65,4 +65,4 @@ DEPENDENCIES
   standardrb (~> 1.0)
 
 BUNDLED WITH
-   2.2.15
+   2.2.22

--- a/README.md
+++ b/README.md
@@ -51,27 +51,39 @@ Easy, but unlikely to be readable. For this you will need to use one of the many
 These are the various QR code generation options provided by the underlying [rqrcode_core](https://github.com/whomwah/rqrcode_core). You may actually only need this library if you don't need the various rendering options `rqrcode` provides, but just need the data structure.
 
 ```
-string - the string you wish to encode
+Expects a string or array (for multi-segment encoding) to be parsed in, other args are optional
 
-size   - the size (Integer) of the qrcode (defaults to smallest size needed to encode the string)
+  data - the string, QRSegment or array of Hashes (with data:, mode: keys) you wish to encode
 
-level  - the error correction level, can be:
-  * Level :l 7%  of code can be restored
-  * Level :m 15% of code can be restored
-  * Level :q 25% of code can be restored
-  * Level :h 30% of code can be restored (default :h)
+  size - the size (Integer) of the QR Code (defaults to smallest size needed to encode the data)
 
-mode   - the mode of the qrcode (defaults to alphanumeric or byte_8bit, depending on the input data):
-  * :number
-  * :alphanumeric
-  * :byte_8bit
-  * :kanji
+  max_size - the max_size (Integer) of the QR Code (default RQRCodeCore::QRUtil.max_size)
+
+  level - the error correction level, can be:
+    * Level :l 7%  of code can be restored
+    * Level :m 15% of code can be restored
+    * Level :q 25% of code can be restored
+    * Level :h 30% of code can be restored (default :h)
+
+  mode - the mode of the QR Code (defaults to :alphanumeric or :byte_8bit, depending on the input data,
+         only used when data is a string):
+    * :number
+    * :alphanumeric
+    * :byte_8bit
+    * :kanji
 ```
 
 Example
 
-```
-qrcode = RQRCodeCore::QRCode.new('hello world', size: 1, level: :m, mode: :alphanumeric)
+```ruby
+simple_qrcode = RQRCodeCore::QRCode.new("https://kyan.com", size: 1, level: :m, mode: :alphanumeric)
+
+segment_qrcode = QRCodeCore::QRCode.new({ data: "foo", mode: :byte_8bit })
+
+multi_qrcode = RQRCodeCore::QRCode.new([
+  { data: 'foo', mode: :byte_8bit },
+  { data: 'bar1', mode: :alphanumeric }
+])
 ```
 
 ## Render types

--- a/lib/rqrcode/version.rb
+++ b/lib/rqrcode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RQRCode
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 # The generated `.rspec` file contains `--require spec_helper` which will cause
 # this file to always be loaded, without a need to explicitly require it in any
 # files.
+require "bundler/setup"
 require "rqrcode"
 #
 # Given that it is always loaded, you are encouraged to keep this file as


### PR DESCRIPTION
## [2.1.0] - 2021-08-26

- Sync Gemfile.lock with `rqrcode_core.1.2.0` [Adds Multimode Support](https://github.com/whomwah/rqrcode_core#multiple-encoding-support)
- Add badge for Standard linting