### PR TITLE
IFS tampering fix

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-IFS=$'\n\t'
+IFS=, read -ra ADDR <<< "${1}"
 set -vx
 
 bundle install


### PR DESCRIPTION
Semgrep detected a potential IFS tampering in the bin/setup file and I propose a sollution for the problem.

Here is a link with details on the vulnerability.
https://semgrep.dev/r?q=bash.lang.security.ifs-tampering.ifs-tampering