### PR TITLE
Improve to_png `color` and `fill` option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ The will produce a PNG using the [ChunkyPNG gem](https://github.com/wvanbergen/c
 ```
 Options:
 
-fill  - Background ChunkyPNG::Color, defaults to 'white'
-color - Foreground ChunkyPNG::Color, defaults to 'black'
+fill  - Background <ChunkyPNG::Color>, defaults to 'white'. Use [] for multi args
+color - Foreground <ChunkyPNG::Color>, defaults to 'black'. Use [] for multi args
 
 When option :file is supplied you can use the following ChunkyPNG constraints:
 

--- a/lib/rqrcode/export/png.rb
+++ b/lib/rqrcode/export/png.rb
@@ -3,15 +3,14 @@
 require "chunky_png"
 
 # This class creates PNG files.
-# Code from: https://github.com/DCarper/rqrcode
 module RQRCode
   module Export
     module PNG
       # Render the PNG from the QR Code.
       #
       # Options:
-      # fill  - Background ChunkyPNG::Color, defaults to 'white'
-      # color - Foreground ChunkyPNG::Color, defaults to 'black'
+      # fill  - Background ChunkyPNG::Color, defaults to 'white'.
+      # color - Foreground ChunkyPNG::Color, defaults to 'black'.
       #
       # When option :file is supplied you can use the following ChunkyPNG constraints
       # color_mode  - The color mode to use. Use one of the ChunkyPNG::COLOR_* constants.
@@ -62,8 +61,8 @@ module RQRCode
 
         googleis = options.length == 0 || !options[:size].nil?
         options = default_img_options.merge(options) # reverse_merge
-        fill = ChunkyPNG::Color(options[:fill])
-        color = ChunkyPNG::Color(options[:color])
+        fill = ChunkyPNG::Color(*(options[:fill].is_a?(Array) ? options[:fill] : [options[:fill]]))
+        color = ChunkyPNG::Color(*(options[:color].is_a?(Array) ? options[:color] : [options[:color]]))
         output_file = options[:file]
         module_px_size = nil
         border_px = nil

--- a/spec/rqrcode/export_png_spec.rb
+++ b/spec/rqrcode/export_png_spec.rb
@@ -25,6 +25,122 @@ describe "Export::PNG" do
     RQRCode::QRCode.new("png").as_png
   end
 
+  context "with various color inputs" do
+    before :each do
+      allow(ChunkyPNG).to receive(:Color).and_call_original
+      expect(mockImage).to receive(:save)
+        .once
+        .with("some/path", {bit_depth: 1, color_mode: 0})
+    end
+
+    it "should handle the defaults" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 4294967295)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path"
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with("black").once
+      expect(ChunkyPNG).to have_received(:Color).with("white").once
+    end
+
+    it "should handle a blue 'color'" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 4294967295)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        color: "blue"
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with("blue").once
+      expect(ChunkyPNG).to have_received(:Color).with("white").once
+    end
+
+    it "should handle a #FC0000 'color'" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 4294967295)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        color: "#FC0000"
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with("#FC0000").once
+      expect(ChunkyPNG).to have_received(:Color).with("white").once
+    end
+
+    it "should handle an rgb 'color'" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 4294967295)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        color: [0, 0, 0]
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with(0, 0, 0).once
+      expect(ChunkyPNG).to have_received(:Color).with("white").once
+    end
+
+    it "should handle a green 'fill'" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 8388863)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        fill: "green"
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with("black").once
+      expect(ChunkyPNG).to have_received(:Color).with("green").once
+    end
+
+    it "should handle an rgb 'fill'" do
+      expect(ChunkyPNG::Image).to receive(:new)
+        .once
+        .with(174, 174, 4294967295)
+        .and_return(mockImage)
+
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        fill: [255, 255, 255]
+      )
+
+      expect(ChunkyPNG).to have_received(:Color).with("black").once
+      expect(ChunkyPNG).to have_received(:Color).with(255, 255, 255).once
+    end
+  end
+
+  it "should not handle nonsense color " do
+    expect {
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        color: "madeupcolor"
+      )
+    }.to raise_error(ArgumentError, "Unknown color name madeupcolor!")
+  end
+
+  it "should not handle nonsense fill " do
+    expect {
+      RQRCode::QRCode.new("png").as_png(
+        file: "some/path",
+        fill: "madeupcolor"
+      )
+    }.to raise_error(ArgumentError, "Unknown color name madeupcolor!")
+  end
+
   context "with file save and constaints" do
     it "should export using the correct defaults" do
       expect(ChunkyPNG::Image).to receive(:new)


### PR DESCRIPTION
As mentioned in https://github.com/whomwah/rqrcode/issues/134 the `to_png` color handling is a bit limited and can produce results that are not clear.

This PR updates how the `color` and `fill` options are handled so you can now pass a single option or a list of options allowing you to pass all variations to `ChunkyPNG::Color` as per their docs https://github.com/wvanbergen/chunky_png/blob/master/lib/chunky_png/color.rb#L33-L41.

#### Examples

```ruby
require "rqrcode"
qr = RQRCode::QRCode.new("https://kyan.com")

# hex black
png = qr.as_png(color: "#000000")
# hex string black
png = qr.as_png(color: "0x000000ff")
# color black
png = qr.as_png(color: "black")
# rgb black
png = qr.as_png(color: [0,0,0])
# rgba black with alpha
png = qr.as_png(color: [0,0,0,50])

File.open("qrcode.png", "w") { |f| f.write png }
```