### PR TITLE
Make chunky_png an optional dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,12 @@ PATH
   remote: .
   specs:
     rqrcode (2.2.0)
-      chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    chunky_png (1.4.0)
     diff-lcs (1.5.0)
     json (2.6.3)
     language_server-protocol (3.17.0.2)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add this line to your application's `Gemfile`:
 
 ```ruby
 gem "rqrcode", "~> 2.0"
+gem "chunky_png", "~> 1.0" # only necessary if you use png export
 ```
 
 or install manually:

--- a/lib/rqrcode/export/png.rb
+++ b/lib/rqrcode/export/png.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
-require "chunky_png"
-
 # This class creates PNG files.
 module RQRCode
   module Export
+    module LazyPNG
+      @mutex = Mutex.new
+      class << self
+        attr_reader :mutex
+      end
+
+      def as_png(options = {})
+        LazyPNG.mutex.synchronize {
+          require "chunky_png"
+          self.class.include PNG unless self.class.include?(PNG)
+        }
+        as_png(options)
+      end
+    end
+
     module PNG
       # Render the PNG from the QR Code.
       #
@@ -130,4 +143,4 @@ module RQRCode
   end
 end
 
-RQRCode::QRCode.send :include, RQRCode::Export::PNG
+RQRCode::QRCode.send :include, RQRCode::Export::LazyPNG

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
   spec.add_dependency "rqrcode_core", "~> 1.0"
-  spec.add_dependency "chunky_png", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
How'd you feel about something like this? It stops requiring chunky_png on boot, instead requiring it on first call of `to_png`.

I'm only using the to_svg method, so it would be nice to get rid of the extra dependency.

The downside is anyone using to_png now needs to include chunky_png in their Gemfile if it's not there already, which probably makes this a breaking change 😞 