### PR TITLE
chore: Updating dependencies and drop Ruby < 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,10 +3,9 @@ name: rqrcode
 on:
   push:
     branches:
-    - master
-  pull_request:
-    branches:
-    - master
+      - main
+      - release
+  pull_request: # Runs on any PR regardless of target branch
 
 jobs:
   Build:
@@ -14,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run Tests for Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
-      run: bundle exec rake spec
-    - name: StandardRB check for Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
-      run: bundle exec standardrb --format progress
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run Tests for Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+        run: bundle exec rake spec
+      - name: StandardRB check for Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+        run: bundle exec standardrb --format progress

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Allow all ChunkyPNG::Color options to be passed into `fill` and `color` on `as_png` [#135]
-* Add 3.2 to CI [@petergoldstein](https://github.com/petergoldstein) [#133]
-* Development dependency upgrades. Minimum Ruby change [#130]
-* README updates
+- Allow all ChunkyPNG::Color options to be passed into `fill` and `color` on `as_png` [#135]
+- Add 3.2 to CI [@petergoldstein](https://github.com/petergoldstein) [#133]
+- Development dependency upgrades. Minimum Ruby change [#130]
+- README updates
 
 ## [2.1.2] - 2022-07-26
 
 ### Changed
 
-* Remove setup script as it just calls bundle install [#128]
-* Change inline styles to the fill property to allow for strict CSP style-src directive [#127]
+- Remove setup script as it just calls bundle install [#128]
+- Change inline styles to the fill property to allow for strict CSP style-src directive [#127]
 
 ## [2.1.1] - 2022-02-11
 
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 
-- The dependency `rqrcode_core-1.0.0` has a tiny breaking change to the `to_s` public method. https://github.com/whomwah/rqrcode_core/blob/master/CHANGELOG.md#breaking-changes
+- The dependency `rqrcode_core-1.0.0` has a tiny breaking change to the `to_s` public method. https://github.com/whomwah/rqrcode_core/blob/main/CHANGELOG.md#breaking-changes
 
 ## [1.2.0] - 2020-12-26
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,14 +15,13 @@ GEM
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     parallel (1.26.3)
-    parser (3.3.4.2)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.7)
     rqrcode_core (1.2.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -37,48 +36,47 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.64.1)
+    rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.2)
+    rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
-    rubocop-performance (1.21.1)
+    rubocop-performance (1.22.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    standard (1.37.0)
+    standard (1.41.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.64.0)
+      rubocop (~> 1.66.0)
       standard-custom (~> 1.0.0)
-      standard-performance (~> 1.4)
+      standard-performance (~> 1.5)
     standard-custom (1.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.50)
-    standard-performance (1.4.0)
+    standard-performance (1.5.0)
       lint_roller (~> 1.1)
-      rubocop-performance (~> 1.21.0)
-    unicode-display_width (2.5.0)
+      rubocop-performance (~> 1.22.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   ruby
   x86_64-linux
-  aarch64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)
   rake (~> 13.0)
   rqrcode!
   rspec (~> 3.5)
-  standard (= 1.37)
+  standard (~> 1.41)
 
 BUNDLED WITH
    2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rqrcode (2.2.0)
       chunky_png (~> 1.0)
-      rqrcode_core (~> 1.0)
+      rqrcode_core (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rqrcode_core (1.2.0)
+    rqrcode_core (2.0.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [RQRCode](https://github.com/whomwah/rqrcode) is a library for creating and rendering QR codes into various formats. It has a simple interface with all the standard QR code options. It was adapted from the Javascript library by Kazuhiko Arase.
 
 * QR code is trademarked by Denso Wave inc
-* Minimum Ruby version is `>= 2.7`
+* Minimum Ruby version is `>= 3.0.0`
 * For `rqrcode` releases `< 2.0.0` please use [this README](https://github.com/whomwah/rqrcode/blob/v1.2.0/README.md)
 * For `rqrcode` releases `< 1.0.0` please use [this README](https://github.com/whomwah/rqrcode/blob/v0.9.0/README.md)
 

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -29,13 +29,11 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7"
-  spec.add_dependency "rqrcode_core", "~> 1.0"
+  spec.required_ruby_version = ">= 3.0.0"
+  spec.add_dependency "rqrcode_core", "~> 2.0"
   spec.add_dependency "chunky_png", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"
-  # We need an explicit lower version as high versons
-  # require us to support Ruby >= 3.0.0
-  spec.add_development_dependency "standard", "1.37"
+  spec.add_development_dependency "standard", "~> 1.41"
 end

--- a/rqrcode.gemspec
+++ b/rqrcode.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/whomwah/rqrcode/issues",
-    "changelog_uri" => "https://github.com/whomwah/rqrcode/blob/master/CHANGELOG.md"
+    "changelog_uri" => "https://github.com/whomwah/rqrcode/blob/main/CHANGELOG.md"
   }
 
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = "~> 3.0"
   spec.add_dependency "rqrcode_core", "~> 2.0"
   spec.add_dependency "chunky_png", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
This pull request introduces several updates to the `rqrcode` project, including changes to Ruby version requirements, dependency updates, and adjustments to CI workflows and documentation. The most significant changes involve raising the minimum Ruby version to `3.0.0`, updating dependencies, and transitioning references from `master` to `main` for consistency.

### Ruby version and dependency updates:
* Updated the minimum Ruby version to `>= 3.0.0` in `README.md` and `rqrcode.gemspec`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[2]](diffhunk://#diff-c5fad5599b5f7dffc4259f0f33f01dcbcb911842f16aa0f5d060f4c4a72806e3L32-R38)
* Updated the `rqrcode_core` dependency to `~> 2.0` and the `standard` development dependency to `~> 1.41` in `rqrcode.gemspec`.

### CI workflow improvements:
* Updated `.github/workflows/ruby.yml` to run on the `main` and `release` branches instead of `master` and added Ruby `3.4` to the CI matrix. Pull requests now trigger workflows regardless of the target branch.

### Documentation updates:
* Changed references from `master` to `main` in `CHANGELOG.md` and `rqrcode.gemspec` to reflect the updated branch naming convention. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL63-R63) [[2]](diffhunk://#diff-c5fad5599b5f7dffc4259f0f33f01dcbcb911842f16aa0f5d060f4c4a72806e3L22-R22)