### PR TITLE
Release 3.2 mergeback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2025-06-12
+
+### Added
+
+- Comprehensive benchmarking suite in `benchmark/` directory for measuring performance and memory usage across all export formats (SVG, PNG, HTML, ANSI)
+- `benchmark_helper.rb` providing shared utilities for IPS, memory, and stack profiling
+- Rake tasks for running benchmarks individually or all at once
+- `benchmark/README.md` explaining usage, metrics, and interpretation of results
+- `AGENTS.md` as a development guide for AI agents
+
+### Changed
+
+- **SVG rendering**: Improved by **+130%** (from 184 i/s to 424 i/s) with **71% memory reduction**
+- **HTML rendering**: Now the fastest export format at **1,876 i/s** (rendering-only benchmark)
+- **Memory efficiency**: HTML now uses **6x less memory** than SVG (previously 22x)
+- Updated minimum Ruby version requirement to >= 3.2.0
+- Updated GitHub workflow Ruby matrix to test only supported versions (3.2, 3.3, 3.4, 4.0)
+- Updated `README.md` with benchmark documentation and contribution guidelines
+
 ## [3.1.1] - 2025-11-25
 
 - Update required_ruby_version to support >= rather than ~> ready for Ruby 4
@@ -83,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump dependencies
 - fix `required_ruby_version` for Ruby 3 support
 
-[unreleased]: https://github.com/whomwah/rqrcode/compare/v3.1.1...HEAD
+[unreleased]: https://github.com/whomwah/rqrcode/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/whomwah/rqrcode/compare/v3.1.1...v3.2.0
 [3.1.1]: https://github.com/whomwah/rqrcode/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/whomwah/rqrcode/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/whomwah/rqrcode/compare/v2.2.0...v3.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rqrcode (3.1.1)
+    rqrcode (3.2.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
 
@@ -105,7 +105,7 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
-  rqrcode (3.1.1)
+  rqrcode (3.2.0)
   rqrcode_core (2.1.0) sha256=f303b85df89c1b8fc5ee8dc19808c9dc4330e6329b660d99d4a8cbb36ca13051
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/lib/rqrcode/version.rb
+++ b/lib/rqrcode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RQRCode
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
This pull request prepares for the 3.2.0 release by updating the version, changelog, and release references. It introduces a comprehensive benchmarking suite, significant performance and memory improvements for SVG and HTML rendering, and updates documentation and Ruby version requirements.

Release and Documentation Updates:
* Added a new section to `CHANGELOG.md` for version 3.2.0, detailing major features, improvements, and changes.
* Updated changelog comparison links to reference the new 3.2.0 release.
* Bumped the gem version in `lib/rqrcode/version.rb` from `3.1.1` to `3.2.0`.

Benchmarking and Performance Improvements:
* Added a full benchmarking suite (`benchmark/`), including utilities and documentation, to measure and compare performance and memory usage across export formats.
* Improved SVG rendering speed by 130% and reduced memory usage by 71%; HTML export is now the fastest and much more memory efficient.

Ruby Version and Workflow Changes:
* Raised the minimum required Ruby version to 3.2.0 and updated GitHub workflow to test only supported Ruby versions.