### PR TITLE
docs: update 3.2.0 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.2.0] - 2025-06-12
+## [3.2.0] - 2026-01-08
 
 ### Added
 


### PR DESCRIPTION
This pull request updates the release date for version `3.2.0` in the `CHANGELOG.md` file to reflect the correct date.

* Changed the release date for `3.2.0` from "2025-06-12" to "2026-01-08" in `CHANGELOG.md`.